### PR TITLE
Bug/lint config fix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,5 +31,11 @@
             }
         ],
         "eol-last": ["error", "always"]
+    },
+
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
     }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,8 +1,8 @@
 {
-    "plugins": [
-        "stylelint-scss"
-    ],
+    "extends": "stylelint-config-standard-scss",
     "rules": {
+        "selector-class-pattern": null,
+        "no-missing-end-of-source-newline": null,
         "custom-property-empty-line-before": null,
         "declaration-empty-line-before": null,
         "declaration-colon-newline-after": null,

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "stylelint": "^14.9.1",
-    "stylelint-scss": "^4.3.0"
+    "stylelint-config-standard-scss": "^5.0.0"
   }
 }

--- a/src/views/About/index.scss
+++ b/src/views/About/index.scss
@@ -1,0 +1,3 @@
+.about__container {
+  text-align: center;
+}

--- a/src/views/About/index.test.js
+++ b/src/views/About/index.test.js
@@ -1,0 +1,9 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import About from "./index.view.tsx"
+
+test("renders about text", () => {
+  render(<About />)
+  const elem = screen.getByText(/About CruzHacks/i)
+  expect(elem).toBeInTheDocument()
+})

--- a/src/views/About/index.view.tsx
+++ b/src/views/About/index.view.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import "./index.scss"
+
+const About: React.FC = () => (
+  <div className='about__container'>About CruzHacks</div>
+)
+
+export default About

--- a/src/views/FAQs/index.scss
+++ b/src/views/FAQs/index.scss
@@ -1,0 +1,3 @@
+.faqs__container {
+  text-align: center;
+}

--- a/src/views/FAQs/index.test.js
+++ b/src/views/FAQs/index.test.js
@@ -1,0 +1,9 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import FAQs from "./index.view"
+
+test("renders FAQs text", () => {
+  render(<FAQs />)
+  const elem = screen.getByText(/FAQ/i)
+  expect(elem).toBeInTheDocument()
+})

--- a/src/views/FAQs/index.view.tsx
+++ b/src/views/FAQs/index.view.tsx
@@ -1,0 +1,6 @@
+import React from "react"
+import "./index.scss"
+
+const FAQs: React.FC = () => <div className='faqs__container'>FAQ</div>
+
+export default FAQs

--- a/src/views/Stats/index.scss
+++ b/src/views/Stats/index.scss
@@ -1,0 +1,3 @@
+.stats__container {
+  text-align: center;
+}

--- a/src/views/Stats/index.test.js
+++ b/src/views/Stats/index.test.js
@@ -1,0 +1,9 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import Stats from "./index.view.tsx"
+
+test("renders stats text", () => {
+  render(<Stats />)
+  const elem = screen.getByText(/Milestones of 2022/i)
+  expect(elem).toBeInTheDocument()
+})

--- a/src/views/Stats/index.view.tsx
+++ b/src/views/Stats/index.view.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import "./index.scss"
+
+const Stats: React.FC = () => (
+  <div className='stats__container'>Milestones of 2022</div>
+)
+
+export default Stats

--- a/src/views/Tracks/index.scss
+++ b/src/views/Tracks/index.scss
@@ -1,0 +1,3 @@
+.tracks__container {
+  text-align: center;
+}

--- a/src/views/Tracks/index.test.js
+++ b/src/views/Tracks/index.test.js
@@ -1,0 +1,9 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import Tracks from "./index.view.tsx"
+
+test("renders tracks text", () => {
+  render(<Tracks />)
+  const elem = screen.getByText(/Prize Tracks/i)
+  expect(elem).toBeInTheDocument()
+})

--- a/src/views/Tracks/index.view.tsx
+++ b/src/views/Tracks/index.view.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import "./index.scss"
+
+const Tracks: React.FC = () => (
+  <div className='tracks__container'>Prize Tracks</div>
+)
+
+export default Tracks

--- a/yarn.lock
+++ b/yarn.lock
@@ -10361,6 +10361,11 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
+postcss-scss@^4.0.2:
+  version "4.0.4"
+  resolved "https://pkgs.dev.azure.com/UnderEverything/Under/_packaging/Under-Shared-Package/npm/registry/postcss-scss/-/postcss-scss-4.0.4.tgz#aa8f60e19ee18259bc193db9e4b96edfce3f3b1f"
+  integrity sha1-qo9g4Z7hglm8GT255Llu384/Ox8=
+
 postcss-selector-not@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/postcss-selector-not/-/postcss-selector-not-6.0.1.tgz#8f0a709bf7d4b45222793fc34409be407537556d"
@@ -11985,10 +11990,39 @@ stylehacks@^5.1.0:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
-stylelint-scss@^4.3.0:
+stylelint-config-recommended-scss@^7.0.0:
+  version "7.0.0"
+  resolved "https://pkgs.dev.azure.com/UnderEverything/Under/_packaging/Under-Shared-Package/npm/registry/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-7.0.0.tgz#db16b6ae6055e72e3398916c0f13d6eb685902a2"
+  integrity sha1-2xa2rmBV5y4zmJFsDxPW62hZAqI=
+  dependencies:
+    postcss-scss "^4.0.2"
+    stylelint-config-recommended "^8.0.0"
+    stylelint-scss "^4.0.0"
+
+stylelint-config-recommended@^8.0.0:
+  version "8.0.0"
+  resolved "https://pkgs.dev.azure.com/UnderEverything/Under/_packaging/Under-Shared-Package/npm/registry/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz#7736be9984246177f017c39ec7b1cd0f19ae9117"
+  integrity sha1-dza+mYQkYXfwF8Oex7HNDxmukRc=
+
+stylelint-config-standard-scss@^5.0.0:
+  version "5.0.0"
+  resolved "https://pkgs.dev.azure.com/UnderEverything/Under/_packaging/Under-Shared-Package/npm/registry/stylelint-config-standard-scss/-/stylelint-config-standard-scss-5.0.0.tgz#afc5e43c73e7a15875b8f30f54204b01a2634743"
+  integrity sha1-r8XkPHPnoVh1uPMPVCBLAaJjR0M=
+  dependencies:
+    stylelint-config-recommended-scss "^7.0.0"
+    stylelint-config-standard "^26.0.0"
+
+stylelint-config-standard@^26.0.0:
+  version "26.0.0"
+  resolved "https://pkgs.dev.azure.com/UnderEverything/Under/_packaging/Under-Shared-Package/npm/registry/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz#4701b8d582d34120eec7d260ba779e4c2d953635"
+  integrity sha1-RwG41YLTQSDux9JguneeTC2VNjU=
+  dependencies:
+    stylelint-config-recommended "^8.0.0"
+
+stylelint-scss@^4.0.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.3.0.tgz#638800faf823db11fff60d537c81051fe74c90fa"
-  integrity sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==
+  resolved "https://pkgs.dev.azure.com/UnderEverything/Under/_packaging/Under-Shared-Package/npm/registry/stylelint-scss/-/stylelint-scss-4.3.0.tgz#638800faf823db11fff60d537c81051fe74c90fa"
+  integrity sha1-Y4gA+vgj2xH/9g1TfIEFH+dMkPo=
   dependencies:
     lodash "^4.17.21"
     postcss-media-query-parser "^0.2.3"


### PR DESCRIPTION
Problem
=======
The linting failed on my local machine and pipeline.
* TS linting gave this React warning: 
`Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration`
* SCSS linting gave this error:
`When linting something other than CSS, you should install an appropriate syntax, e.g. "postcss-scss", and use the "customSyntax" option`

Solution
========
* The React version needed to be specified. I Used the `latest` option ([Github Issue](https://github.com/jsx-eslint/eslint-plugin-react/issues/1955)).
* The new version of stylelint (v14) requires a PostCSS syntax package. You can add this configuration manually, but thought it was a better option to just use a standard config and extend our rules as that is what the stylelint-scss repo recommends. Then I added two scss linting settings (`selector-class-pattern` to allow the __ in the classname selectors and `no-missing-end-of-source-newline` to remove the requirement for newlines at the end of every scss file.
([Github Issue](https://github.com/stylelint-scss/stylelint-scss/issues/541)).

Change Summary:
---------------
* Fix ts and scss lint config

Images/Important Notes (optional):
-----------------------
* I removed the `stylelint-scss` package
* I added the `stylelint-config-standard-scss` package