### PR TITLE
implemented API calls to use user metadata to save theme preference, …

### DIFF
--- a/src/App.test_old
+++ b/src/App.test_old
@@ -27,6 +27,18 @@ jest.mock("@auth0/auth0-react", () => ({
   },
 }))
 
+jest.mock("./contexts/ThemeContext/ThemeContext.tsx", () => ({
+  ThemeProvider: ({ children }) => children,
+  useTheme: () => {
+    return {
+      theme: {
+        mode: "dark"
+      },
+      toggleTheme: jest.fn(),
+    }
+  },
+}))
+
 test("renders welcome text", () => {
   render(<App />, { wrapper: BrowserRouter })
   const elem = screen.getByText(/CruzHacks 2023/i)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Team from "./views/Team/index.view"
 import NavBar from "./components/NavBar/NavBar"
 import "./App.scss"
 import { Routes, Route } from "react-router-dom"
-import ThemeController from "./components/ThemeController"
+import ThemeProvider from "./contexts/ThemeContext/ThemeContext"
 
 const App: React.FC = () => (
   <div className='app'>
@@ -16,7 +16,7 @@ const App: React.FC = () => (
       audience={process.env.REACT_APP_AUTH0_AUDIENCE || ""}
       redirectUri={window.location.origin}
     >
-      <ThemeController>
+      <ThemeProvider>
         <>
           <NavBar />
           <Routes>
@@ -25,7 +25,7 @@ const App: React.FC = () => (
             <Route path='team' element={<Team />} />
           </Routes>
         </>
-      </ThemeController>
+      </ThemeProvider>
     </Auth0ProviderWithHistory>
   </div>
 )

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -3,17 +3,29 @@ import { useAuth0 } from "@auth0/auth0-react"
 import { Link } from "react-router-dom"
 import Login from "../Login/index"
 import Logout from "../Logout/index"
+import { useTheme } from "../../contexts/ThemeContext/ThemeContext"
 import "./NavBar.scss"
 
 const NavBar: React.FC = () => {
   const { isAuthenticated } = useAuth0()
+  const [theme, toggleTheme] = useTheme()
   const auth = () => {
     if (isAuthenticated) return <Logout location={window.location.origin} />
     else return <Login />
   }
+
+  const themeToggle = (
+    <button
+      className='nav__container--items__themeToggle'
+      onClick={() => toggleTheme()}
+    >
+      {theme.mode === "dark" ? "light" : "dark"}
+    </button>
+  )
   return (
     <nav className='nav__container'>
       <ul className='nav__container--items'>
+        <li>{themeToggle}</li>
         <li>
           <Link to='/'>Home</Link>
         </li>

--- a/src/components/ThemeController/index.tsx
+++ b/src/components/ThemeController/index.tsx
@@ -1,16 +1,12 @@
-import React, { useContext } from "react"
-import {
-  ThemeContext,
-  ThemeContextType,
-} from "../../contexts/ThemeContext/ThemeContext"
+import React from "react"
+import { useTheme } from "../../contexts/ThemeContext/ThemeContext"
 
 interface Props {
   children: React.ReactElement
 }
 
 const ThemeController: React.FC<Props> = ({ children }: Props) => {
-  const context = useContext(ThemeContext) as ThemeContextType
-  const [theme] = context
+  const [theme] = useTheme()
 
   return <div className={`app--${theme.mode}`}>{children}</div>
 }

--- a/src/contexts/ThemeContext/ThemeContext.tsx
+++ b/src/contexts/ThemeContext/ThemeContext.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, useState } from "react"
+import React, { createContext, useState, useEffect, useContext } from "react"
+import { getUserTheme, updateUserTheme } from "../../utils/api"
+import { useAuth0 } from "@auth0/auth0-react"
 
 interface Theme {
   mode: "dark" | "light"
@@ -13,28 +15,71 @@ const initialTheme: Theme = {
 }
 
 export type ThemeContextType =
-  | [typeof initialTheme, null]
-  | [Theme, React.Dispatch<React.SetStateAction<Theme>>]
+  | [typeof initialTheme, () => void]
+  | [Theme, () => void]
 
 export const ThemeContext = createContext<ThemeContextType>([
   initialTheme,
-  null,
+  () => {},
 ])
+export const useTheme = () => useContext(ThemeContext)
 
 interface Props {
   children: React.ReactElement
 }
 
-const StateProvider: React.FC<Props> = ({ children }: Props) => {
+export const ThemeProvider: React.FC<Props> = ({ children }: Props) => {
   const [theme, setTheme] = useState(initialTheme)
-
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0()
+  const validThemes = /light|dark/
   // console.log("Theme is", theme)
+  useEffect(() => {
+    /**
+     *  if the user is signed in
+     *  we want to fetch their metadata
+     *  to get the theme they last selected
+     *  and update the context state to match
+     *
+     *  DEPENDENT on isAuthenticated to reduce fetch on re-render
+     */
+    if (isAuthenticated) {
+      getAccessTokenSilently().then(accessToken => {
+        getUserTheme(accessToken)
+          .then(res => {
+            console.log(res)
+            if (res.status === 200) {
+              console.log(res.data.theme)
+              if (
+                res.data.theme &&
+                res.data.theme.match(validThemes) &&
+                res.data.theme !== theme
+              ) {
+                setTheme({ mode: res.data.theme })
+              } else throw "invalid theme"
+            } else throw "unable to fetch requested resource"
+          })
+          .catch(err => console.log(err))
+      })
+    }
+  }, [isAuthenticated])
+
+  const toggleTheme = () => {
+    const newTheme: Theme = {
+      mode: theme.mode === "dark" ? "light" : "dark",
+    }
+    setTheme(newTheme)
+    if (isAuthenticated) {
+      getAccessTokenSilently().then(accessToken => {
+        updateUserTheme(newTheme.mode, accessToken)
+      })
+    }
+  }
 
   return (
-    <ThemeContext.Provider value={[theme, setTheme]}>
-      {children}
+    <ThemeContext.Provider value={[theme, toggleTheme]}>
+      <div className={`app--${theme.mode}`}>{children}</div>
     </ThemeContext.Provider>
   )
 }
 
-export default StateProvider
+export default ThemeProvider

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -9,6 +9,9 @@ const RESEND_VERIFICATION_EMAIL_ENDPOINT =
 const SUBSCRIBE_ENDPOINT =
   `${process.env.REACT_APP_MAILCHIMP_ENDPOINT}/subscribe` || ""
 
+const METADATA_ENDPOINT =
+  `${process.env.REACT_APP_ENDPOINT_URL}/auth/metadata` || ""
+
 const API_KEY = process.env.REACT_APP_API_KEY || ""
 
 export function resendVerificationEmail(
@@ -70,5 +73,32 @@ export function verifyRecaptchaToken(res: string | null, callback: any) {
       }
       return response
     }) // after response 200, token validated: unlock verification button
+    .catch(err => err)
+}
+
+export function updateUserTheme(theme: string, authToken: string) {
+  const axiosConfig: AxiosRequestConfig = {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  }
+  const body = {
+    theme,
+  }
+  return axios
+    .patch(METADATA_ENDPOINT, body, axiosConfig)
+    .then((res: AxiosResponse) => res)
+    .catch(err => err)
+}
+
+export function getUserTheme(authToken: string) {
+  const axiosConfig: AxiosRequestConfig = {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  }
+  return axios
+    .get(METADATA_ENDPOINT, axiosConfig)
+    .then((res: AxiosResponse) => res)
     .catch(err => err)
 }


### PR DESCRIPTION
…updated navbar.tsx and ThemeContext accordingly

Problem
=======
We needed some way to save theme to user's account [Jira](https://cruzhacks-dev.atlassian.net/browse/CRUZ-44)



Solution
========
What I/we did to solve this problem
Added Api Calls to Api.tsx
Added logic to ThemeContext
Added light/dark toggle to navbar


Change Summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  